### PR TITLE
[COOK-1239] users recipe will not remove users certs if they have action:remove

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.99.3:
+
+* [COOK-1239] - updated openvpn recipe to match users cookbook and remove users w/ action:remove
+
 ## v0.99.2:
 
 * [COOK-564] - fix users recipe search, add port attribute

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email  "cookbooks@opscode.com"
 license           "Apache 2.0"
 description       "Installs and configures openvpn and includes rake tasks for managing certs"
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.99.2"
+version           "0.99.3"
 
 recipe "openvpn", "Installs and configures openvpn"
 recipe "openvpn::users", "Sets up openvpn cert/configs for users data bag items"

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -17,7 +17,16 @@
 # limitations under the License.
 #
 
-search("users", "*:*") do |u|
+search("users", "action:remove") do |u|
+  execute "remove-openvpn-#{u['id']}" do
+    cwd node["openvpn"]["key_dir"]
+    command <<-EOH
+      rm -f #{u['id']}.crt #{u['id']}.key #{u['id']}.conf #{u['id']}.ovpn
+    EOH
+  end
+end
+
+search("users", "NOT action:remove") do |u|
   execute "generate-openvpn-#{u['id']}" do
     command "./pkitool #{u['id']}"
     cwd "/etc/openvpn/easy-rsa"


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-1239

updated openvpn recipe to match users cookbook and remove users w/ action:remove
