### PR TITLE
Set script-security = 2 by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -29,7 +29,7 @@ default["openvpn"]["key_dir"] = "/etc/openvpn/keys"
 default["openvpn"]["signing_ca_key"]  = "#{node["openvpn"]["key_dir"]}/ca.key"
 default["openvpn"]["signing_ca_cert"] = "#{node["openvpn"]["key_dir"]}/ca.crt"
 default["openvpn"]["routes"] = []
-default["openvpn"]["script_security"] = 1
+default["openvpn"]["script_security"] = 2
 
 # Used by helper library to generate certificates/keys
 default["openvpn"]["key"]["ca_expire"] = 3650


### PR DESCRIPTION
Newer versions of openvpn require script-security = 2 to execute
/etc/openvpn/server.up.sh. openvpn fails to start with script-security = 1
