### PR TITLE
[COOK-2513] Changed user and group to attributes. Set different RHEL/Cen...

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -30,7 +30,13 @@ default["openvpn"]["signing_ca_key"]  = "#{node["openvpn"]["key_dir"]}/ca.key"
 default["openvpn"]["signing_ca_cert"] = "#{node["openvpn"]["key_dir"]}/ca.crt"
 default["openvpn"]["routes"] = []
 default["openvpn"]["script_security"] = 1
-
+default["openvpn"]["user"] = "nobody" 
+case platform
+when "redhat", "centos", "fedora"
+  default["openvpn"]["group"] = "nobody" 
+else 
+  default["openvpn"]["group"] = "nogroup" 
+end
 # Used by helper library to generate certificates/keys
 default["openvpn"]["key"]["ca_expire"] = 3650
 default["openvpn"]["key"]["expire"]    = 3650

--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -31,8 +31,8 @@ ifconfig-pool-persist /etc/openvpn/ipp.txt
 <%= node["openvpn"]["type"] %> <%= node["openvpn"]["subnet"] %> <%= node["openvpn"]["netmask"] %>
 <% end -%>
 
-user nobody
-group nogroup
+user <%= node["openvpn"]["user"] %>
+group <%= node["openvpn"]["group"] %>
 
 # avoid accessing certain resources on restart 
 persist-key


### PR DESCRIPTION
...t/Fedora group default to resolve issue with OpenVPN startup failure on CentOS due to non-existent "nogroup" group.
