### PR TITLE
Added ability for the server to bind to all addresses by leaving local = ""

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Attributes
 
 These attributes are set by the cookbook by default.
 
-* `node["openvpn"]["local"]` - IP to listen on, defaults to node[:ipaddress]
+* `node["openvpn"]["local"]` - IP to listen on, defaults to node[:ipaddress], leave blank "" to listen on all addresses.
 * `node["openvpn"]["proto"]` - Valid values are 'udp' or 'tcp', defaults to 'udp'.
 * `node["openvpn"]["port"]` - Port to listen on, defaults to '1194'.
 * `node["openvpn"]["type"]` - Valid values are 'server' or 'server-bridge'. Default is 'server' and it will create a routed IP tunnel, and use the 'tun' device. 'server-bridge' will create an ethernet bridge and requires a tap0 device bridged with the ethernet interface, and is beyond the scope of this cookbook.

--- a/templates/default/server.conf.erb
+++ b/templates/default/server.conf.erb
@@ -11,7 +11,9 @@ dev tun
 <% end -%>
 keepalive 10 120
 comp-lzo
+<% if node["openvpn"]["local"] != "" -%>
 local <%= node["openvpn"]["local"] %>
+<% end -%>
 <% if node['openvpn']['routes'] -%>
 <% node["openvpn"]["routes"].each do |route| -%>
 <%= route %>


### PR DESCRIPTION
...ocal"] = ""

This is especially useful for Amazon EC2 and other NAT'd instances.

@anthroprose
