### PR TITLE
[COOK-4263] -  OpenVPN users recipe should run in Chef-Solo when chef-solo-search installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Sets up an OpenVPN server.
 
 ### users
 Utilizes a data bag called `users` to generate OpenVPN keys for each user.
+[chef-solo-search](https://github.com/edelight/chef-solo-search) is required in order to use this recipe with Chef-Solo, although it is not a dependency of this cookbook.
 
 
 Usage

--- a/recipes/users.rb
+++ b/recipes/users.rb
@@ -17,8 +17,15 @@
 # limitations under the License.
 #
 
-if Chef::Config[:solo]
-  Chef::Log.warn 'The openvpn::users recipe requires a Chef Server, skipping.'
+def chef_solo_search_installed?
+  klass = ::Search::const_get('Helper')
+  return klass.is_a?(Class)
+rescue NameError
+  return false
+end
+
+if Chef::Config[:solo] && !chef_solo_search_installed?
+  Chef::Log.warn("This recipe uses search. Chef-Solo does not support search unless you install the chef-solo-search cookbook.")
 else
   search('users', '*:*') do |u|
     execute "generate-openvpn-#{u['id']}" do


### PR DESCRIPTION
I've added an additional check in the users recipe to see if the [chef-solo-search](https://github.com/edelight/chef-solo-search) cookbook is installed when running in Chef-Solo. If it is then data_bag search will work and the recipe can proceed normally.

The code that I used is taken from/inspired by the way that the [opscode users](https://github.com/opscode-cookbooks/users) cookbook detects if chef-solo-search is installed.

I'm not sure how to write tests for this, but for what it's worth I've used it on an Ubuntu 13.04 x64 Vagrant box and it works as expected. I have the repo set up [here](https://github.com/charlesbjohnson/vpn_on_vps).

Please see issue [4263](https://tickets.opscode.com/browse/COOK-4263) for more info.

Thanks.
