### PR TITLE
[COOK-4277] Attributize status_log attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ These attributes are set by the cookbook by default.
 * `node["openvpn"]["netmask"]` - Netmask for the subnet, default is 255.255.0.0.
 * `node["openvpn"]["gateway"]` - FQDN for the VPN gateway server. Default is `node["fqdn"]`.
 * `node["openvpn"]["log"]` - Server log file. Default /var/log/openvpn.log
+* `node["openvpn"]["status_log"]` - Connection status log file. Default /etc/openvpn/openvpn-status.log
 * `node["openvpn"]["key_dir"]` - Location to store keys, certificates and related files. Default `/etc/openvpn/keys`.
 * `node["openvpn"]["signing_ca_cert"]` - CA certificate for signing, default `/etc/openvpn/keys/ca.crt`
 * `node["openvpn"]["signing_ca_key"]` - CA key for signing, default `/etc/openvpn/keys/ca.key`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -25,6 +25,7 @@ default['openvpn']['subnet']          = '10.8.0.0'
 default['openvpn']['netmask']         = '255.255.0.0'
 default['openvpn']['gateway']         = "vpn.#{node["domain"]}"
 default['openvpn']['log']             = '/var/log/openvpn.log'
+default['openvpn']['status_log']      = '/etc/openvpn/openvpn-status.log'
 default['openvpn']['key_dir']         = '/etc/openvpn/keys'
 default['openvpn']['signing_ca_key']  = "#{node["openvpn"]["key_dir"]}/ca.key"
 default['openvpn']['signing_ca_cert'] = "#{node["openvpn"]["key_dir"]}/ca.crt"

--- a/metadata.rb
+++ b/metadata.rb
@@ -65,6 +65,12 @@ attribute 'openvpn/log',
           :default      => '/var/log/openvpn.log',
           :recipes      => ['openvpn']
 
+attribute 'openvpn/status_log',
+          :display_name => 'OpenVPN Status Log File',
+          :description  => 'OpenVPN Status log file. Default /etc/openvpn/openvpn-status.log',
+          :default      => '/etc/openvpn/openvpn-status.log',
+          :recipes      => ['openvpn']
+
 attribute 'openvpn/key_dir',
           :display_name => 'OpenVPN Key Directory',
           :description  => 'Location to store keys, certificates and related files. Default /etc/openvpn/keys',

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -138,6 +138,7 @@ openvpn_conf 'server' do
   user node['openvpn']['user']
   group node['openvpn']['group']
   log node['openvpn']['log']
+  status_log node['openvpn']['status_log']
   only_if { node['openvpn']['configure_default_server'] }
   notifies :restart, 'service[openvpn]'
 end

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -42,5 +42,5 @@ attribute :duplicate_cn, :kind_of => [TrueClass, FalseClass], :default => false
 attribute :interface_num, :kind_of => Integer
 attribute :client_subnet_route, :kind_of => String
 attribute :max_clients, :kind_of => Integer
-attribute :status_log, :kind_of => String, :default => '/etc/openvpn/openvpn-status.log'
+attribute :status_log, :kind_of => String
 attribute :plugins, :kind_of => Array, :default => []


### PR DESCRIPTION
The default location of the status_log LWRP attribute causes the service start
to fail under CentOS w/SeLinux enabled. This can be mitigated by changing the
status_log setting to use /var/log/openvpn, which has the correct SEL context.
In order to to that, the attribute needs to be changeable using node
attributes.
- Add openvpn/status_log attribute
- Change LWRP call in default recipe to pass status_log attribute
- Move LWRP attribute default to attributes file like other configurable
  attributes
- Update metdata with new attribute
- Update README with new attribute

See: https://tickets.opscode.com/browse/COOK-4277
