### PR TITLE
Fix the openvpn port attribute in Rakefile

### DIFF
--- a/templates/default/Rakefile.erb
+++ b/templates/default/Rakefile.erb
@@ -48,7 +48,7 @@ task :client do
 client
 dev tun
 proto <%= node['openvpn']['config']['proto'] %>
-remote #{gateway} <%= node['openvpn']['port'] %>
+remote #{gateway} <%= node['openvpn']['config']['port'] %>
 resolv-retry infinite
 nobind
 persist-key


### PR DESCRIPTION
### Description

The .conf and .ovpn files generated with rake doesn't have the openvpn port on the remote line.

### Issues Resolved

#106 

### Check List

- [x] All tests pass.