### PR TITLE
Don't set IPv6 sysctl property when IPv6 is disabled

### DIFF
--- a/recipes/enable_ip_forwarding.rb
+++ b/recipes/enable_ip_forwarding.rb
@@ -30,5 +30,6 @@ else
 
   sysctl_param 'net.ipv6.conf.all.forwarding' do
     value 1
+    only_if { Dir.exist? '/proc/sys/net/ipv6' }
   end
 end


### PR DESCRIPTION
Unfortunately Ohai doesn't have a plugin for this.