### PR TITLE
Occasionaly refresh the CRL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This file is used to list changes made in each version of the openvpn cookbook.
 ## unreleased
 
 - Add integration testing on CircleCI
+- [Periodically refresh the CRL](https://github.com/sous-chefs/openvpn/pull/129)
+  - Sign it with the correct certificate & algorithm. Use CRL v2.
 
 ## v4.0.0 (Jan 21, 2019)
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ The following lets you specify the message digest used for generating certificat
 
 - `node['openvpn']['key']['message_digest']` - Default is `sha256` for a high-level of security.
 
+The CRL will be generated, and refreshed automatically, allowing you to
+revoke certificates
+
+- `node['openvpn']['key']['crl_expire']` - In how many days should the CRL expire? Will be refreshed after half of this time
+
 ## Recipes
 
 ### `openvpn::default`

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -35,6 +35,7 @@ default['openvpn']['git_package'] = false
 # Used by helper library to generate certificates/keys
 default['openvpn']['key']['ca_expire']      = 3650
 default['openvpn']['key']['expire']         = 3650
+default['openvpn']['key']['crl_expire']     = 30
 default['openvpn']['key']['size']           = 2048
 default['openvpn']['key']['country']        = 'US'
 default['openvpn']['key']['province']       = 'CA'

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -139,6 +139,7 @@ execute 'gencrl' do
   command "openssl ca -config #{[node['openvpn']['fs_prefix'], '/etc/openvpn/easy-rsa/openssl.cnf'].join} " \
           '-gencrl ' \
           '-crlexts crl_ext ' \
+          "-md #{node['openvpn']['key']['message_digest']} " \
           "-keyfile #{key_dir}/ca.key " \
           "-cert #{key_dir}/ca.crt " \
           "-out #{key_dir}/crl.pem"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -136,7 +136,9 @@ end
 
 execute 'gencrl' do
   environment('KEY_CN' => "#{node['openvpn']['key']['org']} CA")
-  command "openssl ca -config #{[node['openvpn']['fs_prefix'], '/etc/openvpn/easy-rsa/openssl.cnf'].join} -gencrl " \
+  command "openssl ca -config #{[node['openvpn']['fs_prefix'], '/etc/openvpn/easy-rsa/openssl.cnf'].join} " \
+          '-gencrl ' \
+          '-crlexts crl_ext ' \
           "-keyfile #{key_dir}/ca.key " \
           "-cert #{key_dir}/ca.crt " \
           "-out #{key_dir}/crl.pem"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -144,7 +144,8 @@ execute 'gencrl' do
           "-out #{key_dir}/crl.pem"
   not_if {
     ::File.exist?("#{key_dir}/crl.pem") &&
-    ::File.mtime("#{key_dir}/crl.pem") >= renew_after.to_time
+    ::File.mtime("#{key_dir}/crl.pem") >= renew_after.to_time &&
+    ::File.mtime("#{key_dir}/crl.pem") >= ::File.mtime("#{key_dir}/index.txt")
   }
   action  :run
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -139,12 +139,12 @@ renew_after = ::Date.today - node['openvpn']['key']['crl_expire'] / 2
 execute 'gencrl' do
   environment('KEY_CN' => "#{node['openvpn']['key']['org']} CA")
   command "openssl ca -config #{[node['openvpn']['fs_prefix'], '/etc/openvpn/easy-rsa/openssl.cnf'].join} -gencrl " \
-          "-keyfile #{node['openvpn']['key_dir']}/server.key " \
-          "-cert #{node['openvpn']['key_dir']}/server.crt " \
-          "-out #{node['openvpn']['key_dir']}/crl.pem"
+          "-keyfile #{key_dir}/server.key " \
+          "-cert #{key_dir}/server.crt " \
+          "-out #{key_dir}/crl.pem"
   not_if {
-    ::File.exist?("#{node['openvpn']['key_dir']}/crl.pem") &&
-    ::File.mtime("#{node['openvpn']['key_dir']}/crl.pem") >= renew_after.to_time
+    ::File.exist?("#{key_dir}/crl.pem") &&
+    ::File.mtime("#{key_dir}/crl.pem") >= renew_after.to_time
   }
   action  :run
 end
@@ -152,7 +152,7 @@ end
 # Make a world readable copy of the CRL
 remote_file [node['openvpn']['fs_prefix'], '/etc/openvpn/crl.pem'].join do
   mode   '644'
-  source "file://#{node['openvpn']['key_dir']}/crl.pem"
+  source "file://#{key_dir}/crl.pem"
 end
 
 # the FreeBSD service expects openvpn.conf

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -137,8 +137,8 @@ end
 execute 'gencrl' do
   environment('KEY_CN' => "#{node['openvpn']['key']['org']} CA")
   command "openssl ca -config #{[node['openvpn']['fs_prefix'], '/etc/openvpn/easy-rsa/openssl.cnf'].join} -gencrl " \
-          "-keyfile #{key_dir}/server.key " \
-          "-cert #{key_dir}/server.crt " \
+          "-keyfile #{key_dir}/ca.key " \
+          "-cert #{key_dir}/ca.crt " \
           "-out #{key_dir}/crl.pem"
   only_if do
     crl = "#{key_dir}/crl.pem"

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -147,7 +147,7 @@ execute 'gencrl' do
     ::File.mtime("#{key_dir}/crl.pem") >= renew_after.to_time &&
     ::File.mtime("#{key_dir}/crl.pem") >= ::File.mtime("#{key_dir}/index.txt")
   }
-  action  :run
+  action :run
 end
 
 # Make a world readable copy of the CRL

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -36,8 +36,8 @@ describe 'openvpn::server' do
       expect(chef_run).to run_execute('gencrl').with(
         environment: { 'KEY_CN' => 'Fort Funston CA' },
         command: 'openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf -gencrl ' \
-                 '-keyfile /etc/openvpn/keys/server.key ' \
-                 '-cert /etc/openvpn/keys/server.crt ' \
+                 '-keyfile /etc/openvpn/keys/ca.key ' \
+                 '-cert /etc/openvpn/keys/ca.crt ' \
                  '-out /etc/openvpn/keys/crl.pem'
       )
     end

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -42,6 +42,7 @@ describe 'openvpn::server' do
         command: 'openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf ' \
                  '-gencrl ' \
                  '-crlexts crl_ext ' \
+                 '-md sha256 ' \
                  '-keyfile /etc/openvpn/keys/ca.key ' \
                  '-cert /etc/openvpn/keys/ca.crt ' \
                  '-out /etc/openvpn/keys/crl.pem'

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -39,7 +39,9 @@ describe 'openvpn::server' do
     it 'executes gencrl with correction parameters' do
       expect(chef_run).to run_execute('gencrl').with(
         environment: { 'KEY_CN' => 'Fort Funston CA' },
-        command: 'openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf -gencrl ' \
+        command: 'openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf ' \
+                 '-gencrl ' \
+                 '-crlexts crl_ext ' \
                  '-keyfile /etc/openvpn/keys/ca.key ' \
                  '-cert /etc/openvpn/keys/ca.crt ' \
                  '-out /etc/openvpn/keys/crl.pem'

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -38,8 +38,7 @@ describe 'openvpn::server' do
         command: 'openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf -gencrl ' \
                  '-keyfile /etc/openvpn/keys/server.key ' \
                  '-cert /etc/openvpn/keys/server.crt ' \
-                 '-out /etc/openvpn/keys/crl.pem',
-        creates: '/etc/openvpn/keys/crl.pem'
+                 '-out /etc/openvpn/keys/crl.pem'
       )
     end
 

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -14,6 +14,10 @@ describe 'openvpn::server' do
       end.converge(described_recipe)
     end
 
+    before do
+      allow(::File).to receive(:mtime).with('/etc/openvpn/keys/index.txt').and_return(Time.now - 31 * 60 * 24)
+    end
+
     it 'converges successfully' do
       expect { chef_run }.to_not raise_error
     end

--- a/templates/openssl.cnf.erb
+++ b/templates/openssl.cnf.erb
@@ -21,7 +21,7 @@ private_key	= <%= node['openvpn']['signing_ca_key'] %>
 RANDFILE	= $dir/.rand
 x509_extensions	= usr_cert
 default_days	= <%= node['openvpn']['key']['ca_expire'] %>
-default_crl_days= 30
+default_crl_days	= <%= node['openvpn']['key']['crl_expire'] %>
 default_md	= md5
 preserve	= no
 policy		= policy_anything


### PR DESCRIPTION
### Description

Refresh the CRL once every 15 days, by default, or after creating/revoking a certificate.

And tweak the format of the CRL, while we're here.

### Issues Resolved

* Currently, the CRL is configured to expire after 30 days. And nothing will refresh it. So the VPN server isn't useful after 30 days.
* Don't use MD5 for the CRL, use the configured hash (presumably SHA-256).
* Use CRL format 2.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable