### PR TITLE
Add the official OpenVPN apt repositori when running on a debian family system.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ description       'Installs and configures openvpn and includes rake tasks for m
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url        'https://github.com/sous-chefs/openvpn'
 issues_url        'https://github.com/sous-chefs/openvpn/issues'
-chef_version      '>= 12.7' if respond_to?(:chef_version)
+chef_version      '>= 12.9' if respond_to?(:chef_version)
 
 supports 'arch'
 supports 'centos'

--- a/recipes/apt-repo.rb
+++ b/recipes/apt-repo.rb
@@ -1,0 +1,10 @@
+#
+# Cookbook:: openvpn
+# Recipe:: apt-repo
+#
+
+apt_repository 'openvpn' do
+  uri        'http://build.openvpn.net/debian/openvpn/stable/'
+  key        'https://swupdate.openvpn.net/repos/repo-public.gpg'
+  components ['main']
+end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -17,6 +17,7 @@
 # limitations under the License.
 
 include_recipe 'yum-epel' if platform_family?('rhel')
+include_recipe 'openvpn::apt-repo' if platform_family?('debian')
 
 if node['openvpn']['git_package'] == true
   package 'openvpn-git'


### PR DESCRIPTION
### Description
Add the official OpenVPN apt repositori when running on a debian family system.
This adds the stable version of the repository.


### Issues Resolved
This fixes issue #131 

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD> (complains about label etc)
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
