### PR TITLE
Fix genctl execute

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -135,10 +135,10 @@ end
 end
 
 execute 'gencrl' do
-  environment('KEY_CN' => "#{node['openvpn']['key']['org']} CA")
+  environment('KEY_CN' => "server")
   command "openssl ca -config #{[node['openvpn']['fs_prefix'], '/etc/openvpn/easy-rsa/openssl.cnf'].join} -gencrl " \
-          "-keyfile #{node['openvpn']['key_dir']}/server.key " \
-          "-cert #{node['openvpn']['key_dir']}/server.crt " \
+          "-keyfile #{node['openvpn']['signing_ca_key']} " \
+          "-cert #{node['openvpn']['signing_ca_cert']} " \
           "-out #{node['openvpn']['key_dir']}/crl.pem"
   creates "#{node['openvpn']['key_dir']}/crl.pem"
   action  :run


### PR DESCRIPTION
The current execute that generates CRL is broken. CRL should be updated using CA certificate, not the client certificate (server.crt). 

How to test:
- Create a new user
- Connect with the new certificate to OpenVPN
- Revoke the test user
```
export KEY_CN=server && \
    . /etc/openvpn/easy-rsa/vars && \
    openssl ca -revoke /etc/openvpn/keys/TESTUSER.crt \
    -config /etc/openvpn/easy-rsa/openssl.cnf
```
- Gegerate new CRL using command from `gencrl` execute
```
export KEY_CN=MYORG && \
    openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf -gencrl \
      -keyfile /etc/openvpn/keys/server.key \
      -cert /etc/openvpn/keys/server.crt \
      -out /etc/openvpn/keys/crl.pem
```
After that you still will be able to log in using revoked certificate.
The correct revoke will be using ca.crt
```
export KEY_CN=server && \
    openssl ca -config /etc/openvpn/easy-rsa/openssl.cnf -gencrl \
      -keyfile /etc/openvpn/keys/ca.key \
      -cert /etc/openvpn/keys/ca.crt \
      -out /etc/openvpn/keys/crl.pem
```

Fix in PR.