### PR TITLE
Disable the unique_subject requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This file is used to list changes made in each version of the openvpn cookbook.
 - Add integration testing on CircleCI
 - [Periodically refresh the CRL](https://github.com/sous-chefs/openvpn/pull/129)
   - Sign it with the correct certificate & algorithm. Use CRL v2.
+- [Disable `unique_subject` in the CA](https://github.com/sous-chefs/openvpn/pull/149)
 
 ## v4.0.0 (Jan 21, 2019)
 

--- a/templates/openssl.cnf.erb
+++ b/templates/openssl.cnf.erb
@@ -25,6 +25,7 @@ default_crl_days	= <%= node['openvpn']['key']['crl_expire'] %>
 default_md	= md5
 preserve	= no
 policy		= policy_anything
+unique_subject	= no
 [ policy_match ]
 countryName		= match
 stateOrProvinceName	= match


### PR DESCRIPTION
### Description

This allows more than one key with the same CN to exist in the CA's
database. Which is useful for renewal, as it's the only mode of renewal
supported by easy-rsa.

### Issues Resolved

* Not filed: Unable to create a new client with the same CN as a previous client. E.g. for renewal.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable