### PR TITLE
Looks like -out doesn't work with -gencrl

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -142,7 +142,7 @@ execute 'gencrl' do
           "-md #{node['openvpn']['key']['message_digest']} " \
           "-keyfile #{key_dir}/ca.key " \
           "-cert #{key_dir}/ca.crt " \
-          "-out #{key_dir}/crl.pem"
+          "> #{key_dir}/crl.pem"
   only_if do
     crl = "#{key_dir}/crl.pem"
     generate = false

--- a/spec/unit/recipes/server_spec.rb
+++ b/spec/unit/recipes/server_spec.rb
@@ -45,7 +45,7 @@ describe 'openvpn::server' do
                  '-md sha256 ' \
                  '-keyfile /etc/openvpn/keys/ca.key ' \
                  '-cert /etc/openvpn/keys/ca.crt ' \
-                 '-out /etc/openvpn/keys/crl.pem'
+                 '> /etc/openvpn/keys/crl.pem'
       )
     end
 


### PR DESCRIPTION
### Description

I obviously made a mistake in #129. `-out` doesn't seem to work, but shell redirection does.

Didn't add a changelog entry, as this is a fix to another unreleased change.

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable