### PR TITLE
Install tar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the openvpn cookbook.
 
+## Unreleased
+
+- Install tar package
+
 ## 5.1.0 (2020-07-22)
 
 - Add CentOS 8 support

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -24,3 +24,5 @@ if node['openvpn']['git_package'] == true
 else
   package 'openvpn'
 end
+
+package 'tar'


### PR DESCRIPTION
### Description

[Describe what this change achieves]

Installs `tar` on CentOS 8, as it is required by `resources/user.rb`

[List any existing issues this PR resolves]

`tar` is required by `resources/user.rb`, but is not installed by default on CentOS 8.

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
