### PR TITLE
Add support for Amazon Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - 'amazonlinux-2'
           - 'centos-7'
           - 'centos-8'
           - 'debian-9'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the openvpn cookbook.
 
+## Unreleased
+
+- Add support for Amazon Linux
+
 ## 5.1.2 (2020-10-09)
 
 - Install gpg package (fixes [#183](https://github.com/sous-chefs/openvpn/issues/183))

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -18,6 +18,11 @@ verifier:
 
 # currently only support 2 last major revs of distros (at the most)
 platforms:
+  - name: amazonlinux-2
+    driver:
+      image: dokken/amazonlinux-2
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: debian-8
     driver:
       image: dokken/debian-8

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'yum-epel' if platform_family?('rhel')
+include_recipe 'yum-epel' if platform_family?('rhel', 'amazon')
 include_recipe 'openvpn::apt-repo' if platform_family?('debian')
 
 if node['openvpn']['git_package'] == true

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -40,6 +40,16 @@ when 'fedora'
     to '/usr/lib/systemd/system/openvpn@.service'
   end
   service_name = "openvpn@#{node['openvpn']['type']}.service"
+when 'amazon'
+  case node['platform_version'].to_i
+  when 2
+    link "/etc/systemd/system/multi-user.target.wants/openvpn@#{node['openvpn']['type']}.service" do
+      to '/usr/lib/systemd/system/openvpn@.service'
+    end
+    service_name = "openvpn@#{node['openvpn']['type']}.service"
+  else
+    service_name = 'openvpn'
+  end
 when 'debian'
   service_name = "openvpn@#{node['openvpn']['type']}.service"
 when 'arch'

--- a/test/integration/server/server_test.rb
+++ b/test/integration/server/server_test.rb
@@ -5,6 +5,7 @@ if (os[:name] == 'redhat' && os[:release] >= '7') ||
    (os[:name] == 'centos' && os[:release] < '8') ||
    (os[:name] == 'debian' && os[:release] >= '8') ||
    (os[:name] == 'ubuntu' && os[:release] >= '15.04') ||
+   (os[:name] == 'amazon' && os[:release] >= '2') ||
    (os[:name] == 'fedora')
   describe service('openvpn@server') do
     it { is_expected.to be_enabled }


### PR DESCRIPTION
Add support for OpenVPN service under Amazon Linux 2. AL2 is basically
Redhat 7, so the `case node['platform_family'] when 'rhel'` was used
as the code for `case node['platform_family'] when 'amazon'`.

Fixes #178

Tested on Amazon Linux 2, converges successfully.

Signed-off-by: Josh Gitlin <jgitlin@pinnacle21.com>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
