### PR TITLE
Install gpg package (#183)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the openvpn cookbook.
 
+## Unreleased
+
+- Install gpg package (fixes [#183](https://github.com/sous-chefs/openvpn/issues/183))
+
 ## 5.1.1 (2020-07-29)
 
 - Install tar package

--- a/recipes/apt-repo.rb
+++ b/recipes/apt-repo.rb
@@ -7,7 +7,7 @@ apt_update 'all platforms' do
   action :nothing
 end
 
-apt_package 'gpg' do
+apt_package 'gnupg' do
   action :install
   notifies :update, 'apt_update[all platforms]', :before
 end

--- a/recipes/apt-repo.rb
+++ b/recipes/apt-repo.rb
@@ -3,6 +3,15 @@
 # Recipe:: apt-repo
 #
 
+apt_update 'all platforms' do
+  action :nothing
+end
+
+apt_package 'gpg' do
+  action :install
+  notifies :update, 'apt_update[all platforms]', :before
+end
+
 apt_repository 'openvpn' do
   uri        'http://build.openvpn.net/debian/openvpn/stable/'
   key        'https://swupdate.openvpn.net/repos/repo-public.gpg'


### PR DESCRIPTION
This package is required for `apt-repo` recipe to converge successfully.

### Description

Installs the `gpg` package before adding the `openvpn` repository.

### Issues Resolved

Fixes #183 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
