### PR TITLE
Fix resource conf template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the openvpn cookbook.
 
 ## Unreleased
 
+- Fix openvpn_conf template handling
+
 ## 5.2.0 - *2020-12-21*
 
 - Add support for Amazon Linux

--- a/README.md
+++ b/README.md
@@ -206,6 +206,39 @@ Given a hash of config options it writes out individual openvpn config files.
 
 If you don't want to use the default "server.conf" from the default recipe, set `node['openvpn']["configure_default_server"]` to false, then use this resource to configure things as you like.
 
+#### Example
+
+.pem files should be provided before (e.g.: `cookbook_file`)
+
+```ruby
+openvpn_conf 'myvpn' do
+  config({
+    'client' => '',
+    'dev' => 'tun',
+    'proto' => 'tcp',
+    'remote' => '1.2.3.4 443',
+    'cipher' => 'AES-128-CBC',
+    'tls-cipher' => 'DHE-RSA-AES256-SHA',
+    'auth' => 'SHA1',
+    'nobind' => '',
+    'resolv-retry' => 'infinite',
+    'persist-key' => '',
+    'persist-tun' => '',
+    'ca' => "/etc/openvpn/myvpn/ca.pem",
+    'cert' => "/etc/openvpn/myvpn/cert.pem",
+    'key' => "/etc/openvpn/myvpn/key.pem",
+    'comp-lzo' => '',
+    'verb' => false,
+    'auth-user-pass' => "/etc/openvpn/myvpn/login.conf",
+  })
+end
+
+# for systemd based systems
+service 'openvpn@myvpn' do
+  action [:start, :enable]
+end
+```
+
 ## Customizing Server Configuration
 
 To further customize the server configuration, there are two templates that can be modified in this cookbook.

--- a/resources/conf.rb
+++ b/resources/conf.rb
@@ -18,17 +18,11 @@
 
 property :cookbook, String, default: 'openvpn'
 property :config, Hash
+property :template_source, String, default: 'server.conf.erb'
 property :push_routes, Array
 property :push_options, Array
 
 action :create do
-  # FreeBSD service uses openvpn.conf
-  template_source = if new_resource.name == 'openvpn' || new_resource.name == 'server-bridge'
-                      'server.conf.erb'
-                    else
-                      "#{new_resource.name}.conf.erb"
-                    end
-
   conf_location = if platform_family?('rhel') && node['platform_version'].to_i >= 8
                     "/etc/openvpn/#{new_resource.name}/#{new_resource.name}.conf"
                   else
@@ -37,7 +31,7 @@ action :create do
 
   template [node['openvpn']['fs_prefix'], "#{conf_location}"].join do
     cookbook new_resource.cookbook
-    source template_source
+    source new_resource.template_source
     owner 'root'
     group node['root_group']
     mode '644'


### PR DESCRIPTION
### Description

`openvpn_conf` is unusable with a resource name different than `server`

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
