### PR TITLE
Remove "comp-lzo" as default option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the openvpn cookbook.
 
 ## Unreleased
 
+- Remove comp-lzo as a default option
+
 ## 6.1.0 - *2022-02-24*
 
 - Add certificate properties to user resource

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -91,7 +91,6 @@ default['openvpn']['config']['script-security'] = 2
 default['openvpn']['config']['up']              = [node['openvpn']['fs_prefix'], '/etc/openvpn/server.up.sh'].join
 default['openvpn']['config']['persist-key']     = ''
 default['openvpn']['config']['persist-tun']     = ''
-default['openvpn']['config']['comp-lzo']        = ''
 
 default['openvpn']['config']['ca']              = node['openvpn']['signing_ca_cert']
 default['openvpn']['config']['key']             = "#{node['openvpn']['key_dir']}/server.key"

--- a/templates/Rakefile.erb
+++ b/templates/Rakefile.erb
@@ -56,7 +56,6 @@ persist-tun
 ca ca.crt
 cert #{usercn}.crt
 key #{usercn}.key
-comp-lzo
 verb 3
 <% if node['openvpn']['server_verification'] %>
 <%= node['openvpn']['server_verification'] %>

--- a/templates/client-inline.conf.erb
+++ b/templates/client-inline.conf.erb
@@ -12,7 +12,6 @@ resolv-retry infinite
 nobind
 persist-key
 persist-tun
-comp-lzo
 verb 3
 <ca>
 <%= @ca -%>

--- a/templates/client.conf.erb
+++ b/templates/client.conf.erb
@@ -15,7 +15,6 @@ persist-tun
 ca ca.crt
 cert <%= @client_cn %>.crt
 key <%= @client_cn %>.key
-comp-lzo
 verb 3
 <% if node['openvpn']['server_verification'] %>
 <%= node['openvpn']['server_verification'] %>


### PR DESCRIPTION
Signed-off-by: David Headrick <daviddjh@osuosl.org>

# Description

This change seeks to remove the `comp-lzo` option from this cookbook due to it's deprecated status. More info here: [https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#Option:--comp-lzo](https://community.openvpn.net/openvpn/wiki/DeprecatedOptions#Option:--comp-lzo)

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
