### PR TITLE
fix: replace actionshub/chef-install with Cinc Workstation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@5.0.8
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@main
     permissions:
       actions: write
       checks: write
@@ -35,12 +35,11 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v6
-      - name: Install Chef
-        uses: actionshub/chef-install@6.0.0
+      - name: Install Workstation
+        uses: sous-chefs/.github/.github/actions/install-workstation@main
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:
-          CHEF_LICENSE: accept-no-persist
           KITCHEN_LOCAL_YAML: kitchen.dokken.yml
         with:
           suite: ${{ matrix.suite }}


### PR DESCRIPTION
Replace `actionshub/chef-install` with the `sous-chefs/.github` Cinc Workstation composite action per [sous-chefs/.github#54](https://github.com/sous-chefs/.github/commit/d2b9febbcc412d5c8362361bb4431cd72ddd1b17).

- Use `sous-chefs/.github/.github/actions/install-workstation@main` for integration jobs
- Bump `lint-unit.yml` ref to `@main` for Cinc support
- Remove `CHEF_LICENSE` env var (not needed with Cinc)